### PR TITLE
[ROS 2] Change qos of the estop topic

### DIFF
--- a/joy2twist/src/joy2twist_node.cpp
+++ b/joy2twist/src/joy2twist_node.cpp
@@ -18,7 +18,8 @@ Joy2TwistNode::Joy2TwistNode() : Node("joy2twist_node")
 
   if (e_stop_present_) {
     e_stop_sub_ = this->create_subscription<MsgBool>(
-      e_stop_topic_, rclcpp::SystemDefaultsQoS(), std::bind(&Joy2TwistNode::e_stop_cb, this, _1));
+      e_stop_topic_, rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+      std::bind(&Joy2TwistNode::e_stop_cb, this, _1));
     e_stop_reset_client_ = this->create_client<SrvTrigger>(e_stop_reset_srv_);
     e_stop_trigger_client_ = this->create_client<SrvTrigger>(e_stop_trigger_srv_);
   }


### PR DESCRIPTION
without it when joy2twist was launched after panther_ros, estop message wasn't received correctly